### PR TITLE
Added missing methods to CodenerixMetaType needed for pickling

### DIFF
--- a/codenerix/models.py
+++ b/codenerix/models.py
@@ -75,6 +75,12 @@ class CodenerixMetaType(dict):
         super(CodenerixMetaType, self).__delitem__(key)
         del self.__dict__[key]
 
+    def __getnewargs__(self):
+        return tuple()
+
+    def __getstate__(self):
+        return self.__dict__
+
 
 class CodenerixModelBase(models.Model):
     class Meta:


### PR DESCRIPTION
When working with memcached in some model objects, the pickler module try to get the methods __getnewargs__ and __getstate__ from them. Because these methods were not implemented the class were returning None values. This None values were treated later as functions by the native pickler module breaking some functionality.

I added these two methods to my project and it's working again.

Please integrate this change to the main codebase.

My best regards,

idertator